### PR TITLE
firmware: implement improvements from playtest notes

### DIFF
--- a/firmware/litepog/.ccsproject
+++ b/firmware/litepog/.ccsproject
@@ -14,4 +14,5 @@
 	<templateProperties value="id=com.ti.common.project.core.emptyProjectWithMainTemplate_msp430"/>
 	<filesToOpen value="main.c"/>
 	<isTargetManual value="false"/>
+	<sourceLookupPath value=""/>
 </projectOptions>

--- a/firmware/litepog/.cproject
+++ b/firmware/litepog/.cproject
@@ -253,6 +253,7 @@
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compilerID.ADVICE__POWER.697699398" name="Enable checking of ULP power rules (--advice:power)" superClass="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compilerID.ADVICE__POWER" useByScannerDiscovery="false" value="all" valueType="string"/>
+								<option id="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compilerID.OPT_LEVEL.1360688985" name="Optimization level (--opt_level, -O)" superClass="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compilerID.OPT_LEVEL" value="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compilerID.OPT_LEVEL.0" valueType="enumerated"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compiler.inputType__C_SRCS.985756555" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compiler.inputType__CPP_SRCS.1548463997" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compiler.inputType__ASM_SRCS.1867545973" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.MSP430_20.2.compiler.inputType__ASM_SRCS"/>

--- a/firmware/litepog/config.h
+++ b/firmware/litepog/config.h
@@ -11,26 +11,86 @@
 // Number of LEDs in Neopixel strip
 #define NPX_NUM_LEDS 30
 
+// Index of middle LED
+#define NPX_MID_IDX (NPX_NUM_LEDS/2)
+
+// True if even number of LEDs
+#define NPX_EVEN_LEDS (!(NPX_NUM_LEDS % 2))
+
+// Seed for pseudo-random number generator
+#define PRNG_SEED 0xB00B
+
+// Time to wait between allowing button edges during game select
+#define GAME_SELECT_DEBOUNCE_TIME 20
+
+// Width of game selection menu indicator
+#define GAME_SELECT_WIDTH 6
+
 // Time between demo animation frames
 #define DEMO_INTERVAL 10
+
+// Frame divisor for pong demo animation
+#define DEMO_PONG_INTERVAL_DIV 4
+
+// Frame divisor for ping pong demo animation
+#define DEMO_PINGPONG_INTERVAL_DIV 4
+
+// Frame divisor for tug o' war demo animation
+#define DEMO_TUGOWAR_INTERVAL_DIV 2
+
+// Chance of ball being returned each frame of ping pong demo animation (1/N)
+#define DEMO_PINGPONG_RETURN_RATE 9
+
+// Width of the demo animation
+#define DEMO_WIDTH 8
+
+#define DEMO_MIN_IDX (NPX_MID_IDX - DEMO_WIDTH/2)
+#define DEMO_MAX_IDX (NPX_MID_IDX + DEMO_WIDTH/2 - ((DEMO_WIDTH + 1) % 2))
 
 // Time between countdown ticks
 #define COUNTDOWN_INTERVAL 700
 
 // Number of LEDs lit up for each countdown tick
-#define COUNTDOWN_LED_WIDTH (2 - (NPX_NUM_LEDS % 2))
+#define COUNTDOWN_LED_WIDTH (1 + NPX_EVEN_LEDS)
 
 // Number of countdown ticks before game start
 #define COUNTDOWN_NUMBER 3
 
-// Initial time between ball events
-#define BALL_INTERVAL_START 150
+#define COUNTDOWN_MIN_IDX (NPX_MID_IDX - ((COUNTDOWN_NUMBER - 1)*COUNTDOWN_LED_WIDTH + NPX_EVEN_LEDS))
+#define COUNTDOWN_MAX_IDX (NPX_MID_IDX + (COUNTDOWN_NUMBER - 1)*COUNTDOWN_LED_WIDTH)
 
-// Amount of speedup after each rally
-#define BALL_INTERVAL_SPEEDUP 10
+// Brightness of ball return zones
+#define RETURN_ZONE_BRIGHTNESS 15
 
-// Minimum interval time (max ball speed)
-#define BALL_INTERVAL_MIN 50
+// Initial time between ball events for pong
+#define PONG_BALL_INTERVAL_START 70
+
+// Amount of speedup after each rally for pong
+#define PONG_BALL_INTERVAL_SPEEDUP 5
+
+// Minimum interval time (max ball speed) for pong
+#define PONG_BALL_INTERVAL_MIN 40
+
+// Size of return zone for pong
+#define PONG_RETURN_ZONE_WIDTH 3
+
+// Initial time between ball events for pong
+#define PINGPONG_BALL_INTERVAL_START 70
+
+// Amount of speedup after each rally for pong
+#define PINGPONG_BALL_INTERVAL_SPEEDUP 5
+
+// Minimum interval time (max ball speed) for pong
+#define PINGPONG_BALL_INTERVAL_MIN 10
+
+// Size of return zone for pong
+#define PINGPONG_RETURN_ZONE_WIDTH (NPX_MID_IDX - NPX_EVEN_LEDS)
+
+// Debounce time for ping pong button reads
+#define PINGPONG_DEBOUNCE_TIME 3
+
+// Debounce time for tug o' war button reads
+#define TUGOWAR_DEBOUNCE_TIME 3
 
 // Time between winner animation frames
 #define WINNER_INTERVAL 300

--- a/firmware/litepog/init.h
+++ b/firmware/litepog/init.h
@@ -1,0 +1,84 @@
+/*
+ * init.h
+ *
+ *  Created on: Dec 13, 2021
+ *      Author: Jasper
+ */
+
+#ifndef INIT_H_
+#define INIT_H_
+#include <msp430.h>
+#include "config.h"
+
+volatile extern uint64_t counter;
+
+// Set DCO == SMCLK == MCLK == 24 MHz
+void initClock(void) {
+    // Unlock Clock System Control Registers
+    CSCTL0_H = CSKEY_H;
+
+    // Configure DCO to run at 24MHz
+    CSCTL1 |= (DCORSEL);
+    CSCTL1 &= ~(DCOFSEL0 | DCOFSEL1);
+    CSCTL1 |= DCOFSEL_3;
+
+    // Set SMCLK source to DCO
+    CSCTL2 &= ~(SELS0 | SELS1 | SELS2);
+    CSCTL2 |= SELS__DCOCLK;
+
+    // Set SMCLK divider to 1
+    CSCTL3 &= ~(DIVS0 | DIVS1 | DIVS2);
+    CSCTL3 |= DIVS__1;
+
+    // Set MCLK source to DCO
+    //CSCTL2 &= ~(SELM0 | SELM1 | SELM2);
+    CSCTL2 |= SELM__DCOCLK;
+
+    // Set MCLK divider to 1
+    CSCTL3 &= ~(DIVM0 | DIVM1 | DIVM2);
+    CSCTL3 |= DIVM__1;
+}
+
+void initGpio(void) {
+    // Configure buttons as input
+    BTN_PxDIR &= ~(BTN1_PIN | BTN2_PIN);
+
+#ifdef BTN_PULLUP_EN
+    // Enable pullups if required
+    BTN_PxREN |= (BTN1_PIN | BTN2_PIN);
+    BTN_PxOUT |= (BTN1_PIN | BTN2_PIN);
+#endif
+
+    // Configure LEDs as output
+    LED_PxDIR |= (LED1_PIN | LED2_PIN);
+    LED_PxOUT &= ~(LED1_PIN | LED2_PIN);
+
+}
+
+void initTimer(void) {
+    counter = 0;
+
+    // Stop TB1
+    TB1CTL &= ~(MC0 | MC1);
+    TB1CTL |= MC__STOP;
+
+    // Set TB1 source to SMCLK (24 MHz)
+    TB1CTL |= TBSSEL__SMCLK;
+
+    // Set clock division to 8*3==24 (1 MHz timer tick)
+    TB1CTL |= ID__8;
+    TB1EX0 |= TBIDEX_3;
+
+    // Enable TBIFG interrupt
+    TB1CTL |= TBIE;
+
+    // TB1 overflows every 1000 ticks (1 MHz / 1000 == 1 kHz, counter iterates every 1 ms)
+    TB1CCR0 =  1000;
+
+    // Start TB1
+    TB1CTL|= MC__UP;
+}
+
+
+
+#endif /* INIT_H_ */

--- a/firmware/litepog/main.c
+++ b/firmware/litepog/main.c
@@ -1,93 +1,30 @@
 #include <msp430.h> 
 #include <stdbool.h>
 #include <stdint.h>
+#include "init.h"
 #include "ws2812.h"
 #include "config.h"
 #include "color.h"
+#include "util.h"
+
+
+typedef enum {
+    GAME_PONG = 0,     // Rev 1 firmware game with improvements
+    GAME_PINGPONG = 1, // Ping Pong game from promo video
+    GAME_TUGOWAR = 2,  // Tug o' War game from promo video
+
+    // Placeholder names for detecting when the end of the game list is reached
+    _GAME_FIRST = GAME_PONG,
+    _GAME_LAST = GAME_TUGOWAR,
+} GameType;
 
 volatile uint64_t counter;
 
-typedef enum {
-    BTN_WAIT,
-    BTN_HIGH,
-    BTN_LOW
-} ButtonState;
-
-
-// Set DCO == SMCLK == MCLK == 24 MHz
-void initClock(void) {
-    // Unlock Clock System Control Registers
-    CSCTL0_H = CSKEY_H;
-
-    // Configure DCO to run at 24MHz
-    CSCTL1 |= (DCORSEL);
-    CSCTL1 &= ~(DCOFSEL0 | DCOFSEL1);
-    CSCTL1 |= DCOFSEL_3;
-
-    // Set SMCLK source to DCO
-    CSCTL2 &= ~(SELS0 | SELS1 | SELS2);
-    CSCTL2 |= SELS__DCOCLK;
-
-    // Set SMCLK divider to 1
-    CSCTL3 &= ~(DIVS0 | DIVS1 | DIVS2);
-    CSCTL3 |= DIVS__1;
-
-    // Set MCLK source to DCO
-    //CSCTL2 &= ~(SELM0 | SELM1 | SELM2);
-    CSCTL2 |= SELM__DCOCLK;
-
-    // Set MCLK divider to 1
-    CSCTL3 &= ~(DIVM0 | DIVM1 | DIVM2);
-    CSCTL3 |= DIVM__1;
-}
-
-void initGpio(void) {
-    // Configure buttons as input
-    BTN_PxDIR &= ~(BTN1_PIN | BTN2_PIN);
-
-#ifdef BTN_PULLUP_EN
-    // Enable pullups if required
-    BTN_PxREN |= (BTN1_PIN | BTN2_PIN);
-    BTN_PxOUT |= (BTN1_PIN | BTN2_PIN);
-#endif
-
-    // Configure LEDs as output
-    LED_PxDIR |= (LED1_PIN | LED2_PIN);
-    LED_PxOUT &= ~(LED1_PIN | LED2_PIN);
-
-}
-
-void initTimer(void) {
-    counter = 0;
-
-    // Stop TB1
-    TB1CTL &= ~(MC0 | MC1);
-    TB1CTL |= MC__STOP;
-
-    // Set TB1 source to SMCLK (24 MHz)
-    TB1CTL |= TBSSEL__SMCLK;
-
-    // Set clock division to 8*3==24 (1 MHz timer tick)
-    TB1CTL |= ID__8;
-    TB1EX0 |= TBIDEX_3;
-
-    // Enable TBIFG interrupt
-    TB1CTL |= TBIE;
-
-    // TB1 overflows every 1000 ticks (1 MHz / 1000 == 1 kHz, counter iterates every 1 ms)
-    TB1CCR0 =  1000;
-
-    // Start TB1
-    TB1CTL|= MC__UP;
-}
+// Store game type selection in FRAM
+#pragma DATA_SECTION(game_type, ".infoB")
+GameType game_type;
 
 void drawCountDown(uint8_t state) {
-    const uint8_t middle_idx = NPX_NUM_LEDS/2;
-    const uint8_t max_left = (
-            middle_idx - (COUNTDOWN_NUMBER - 1)*COUNTDOWN_LED_WIDTH);
-    const uint8_t max_right = (
-            middle_idx + (COUNTDOWN_NUMBER - 1)*COUNTDOWN_LED_WIDTH
-            + (COUNTDOWN_LED_WIDTH - 1));
     uint8_t i, j;
     uint8_t pos_left, pos_right;
 
@@ -95,8 +32,8 @@ void drawCountDown(uint8_t state) {
     if(state < COUNTDOWN_NUMBER) {
         // Show countdown going up (red lights)
         for(i=0; i<=state; i++) {
-            pos_left = middle_idx - i*COUNTDOWN_LED_WIDTH;
-            pos_right = middle_idx + i*COUNTDOWN_LED_WIDTH;
+            pos_left = NPX_MID_IDX - NPX_EVEN_LEDS - i*COUNTDOWN_LED_WIDTH;
+            pos_right = NPX_MID_IDX - NPX_EVEN_LEDS + i*COUNTDOWN_LED_WIDTH;
             for(j=0; j<COUNTDOWN_LED_WIDTH; j++) {
                 setLEDColor(pos_left + j, 255, 0, 0);
                 setLEDColor(pos_right + j, 255, 0, 0);
@@ -104,19 +41,141 @@ void drawCountDown(uint8_t state) {
         }
     } else {
         // Show countdown finishing (green light)
-        for(i=max_left; i<=max_right; i++)
+        for(i=COUNTDOWN_MIN_IDX; i<=COUNTDOWN_MAX_IDX; i++)
             setLEDColor(i, 0, 255, 0);
     }
     showStrip();
 }
 
+void drawDemoPong(bool show) {
+    static uint64_t last_frame = 0;
+    static uint8_t pos = NPX_MID_IDX;
+    static int8_t dir = 1;
+    static uint8_t frame_div = DEMO_PONG_INTERVAL_DIV;
+    if (counter > last_frame + DEMO_INTERVAL) {
+        last_frame = counter;
+        frame_div--;
+        if(frame_div == 0) {
+            frame_div = DEMO_PONG_INTERVAL_DIV;
+            clearStrip();
+            setLEDColor(DEMO_MIN_IDX, 0, 0, RETURN_ZONE_BRIGHTNESS);
+            setLEDColor(DEMO_MAX_IDX, 0, 0, RETURN_ZONE_BRIGHTNESS);
+            setLEDColor(pos, 0, 0, 255);
+            pos += dir;
+            if(pos <= DEMO_MIN_IDX)
+                dir = 1;
+            else if(pos >= DEMO_MAX_IDX)
+                dir = -1;
+            if(show)
+                showStrip();
+        }
+    }
+}
+
+int8_t pingPongIdx(uint8_t pos) {
+    if(NPX_EVEN_LEDS) {
+        if(pos >= NPX_MID_IDX)
+            return (int8_t)pos - NPX_MID_IDX;
+        else
+            return (int8_t)pos - NPX_MID_IDX + 1;
+    } else {
+        return (int8_t)pos - NPX_MID_IDX;
+    }
+}
+
+void drawDemoPingPong(bool show) {
+    static uint64_t last_frame = 0;
+    static uint8_t pos = NPX_MID_IDX;
+    int8_t side;
+    static int8_t dir = 1;
+    static uint8_t frame_div = DEMO_PINGPONG_INTERVAL_DIV;
+    uint8_t i;
+    if (counter > last_frame + DEMO_INTERVAL) {
+        last_frame = counter;
+        frame_div--;
+        if(frame_div == 0) {
+            frame_div = DEMO_PINGPONG_INTERVAL_DIV;
+            clearStrip();
+            for(i=DEMO_MIN_IDX; i<=DEMO_MAX_IDX; i++) {
+                if(pingPongIdx(i))
+                    setLEDColor(i, 0, 0, RETURN_ZONE_BRIGHTNESS);
+            }
+            pos += dir;
+            side = pingPongIdx(pos);
+            if(!(counter % DEMO_PINGPONG_RETURN_RATE)) {
+                if(side > 0)
+                    dir = -1;
+                else if (side < 0)
+                    dir = 1;
+            }
+            if(pos <= DEMO_MIN_IDX)
+                dir = 1;
+            else if(pos >= DEMO_MAX_IDX)
+                dir = -1;
+
+            setLEDColor(pos, 0, 0, 255);
+            if(show)
+                showStrip();
+        }
+    }
+}
+
+void drawDemoTugOWar(bool show) {
+    static uint64_t last_frame = 0;
+    static uint8_t pos = NPX_MID_IDX;
+    static uint8_t frame_div = DEMO_TUGOWAR_INTERVAL_DIV;
+    if (counter > last_frame + DEMO_INTERVAL) {
+        last_frame = counter;
+        frame_div--;
+        if(frame_div == 0) {
+            frame_div = DEMO_TUGOWAR_INTERVAL_DIV;
+            pos += ((int32_t)fast_rand() % 3) - 1;
+            clearStrip();
+            setLEDColor(pos, 0, 0, 255);
+            if(pos <= DEMO_MIN_IDX)
+                pos += 1;
+            else if(pos >= DEMO_MAX_IDX)
+                pos -= 1;
+            if(show)
+                showStrip();
+        }
+    }
+}
+
+void drawGameSelectIndicator(void) {
+    static uint64_t last_frame = 0;
+    static HsvColor hsv = {0, 255, 100};
+    RgbColor rgb;
+    uint8_t i;
+    if (counter > last_frame + DEMO_INTERVAL) {
+        last_frame = counter;
+        rgb = HsvToRgb(hsv);
+        for(i=0; i<GAME_SELECT_WIDTH; i++)
+            setLEDColor(
+                    NPX_NUM_LEDS - 1 - i, rgb.r, rgb.g, rgb.b);
+
+        showStrip();
+        hsv.h++;
+    }
+}
+
 void demoLoop(void) {
     bool countdown_started = false;
+    void (*demo_anim)(bool);
     uint64_t countdown_start;
-    uint64_t demo_counter = 0;
     uint8_t countdown_state = 0;
-    HsvColor hsv = {0, 255, 100};
-    RgbColor rgb;
+
+    switch(game_type) {
+    case GAME_PONG:
+        demo_anim = &drawDemoPong;
+        break;
+    case GAME_PINGPONG:
+        demo_anim = &drawDemoPingPong;
+        break;
+    case GAME_TUGOWAR:
+        demo_anim = &drawDemoTugOWar;
+        break;
+    }
 
     clearStrip();
     showStrip();
@@ -152,24 +211,18 @@ void demoLoop(void) {
             // Reset countdown, show demo loop
             countdown_started = false;
             countdown_state = 0;
-            if(counter > demo_counter + DEMO_INTERVAL) {
-                demo_counter = counter;
-                rgb = HsvToRgb(hsv);
-                clearStrip();
-                fillStrip(rgb.r, rgb.g, rgb.b);
-                showStrip();
-                hsv.h++;
-            }
+            (*demo_anim)(true);
         }
     }
 }
 
 // Returns 0 if Player 1  wins, 1 if Player 2 wins
-uint8_t gameLoop(void) {
+uint8_t gameLoopPong(void) {
     int8_t dir;
     int32_t pos = NPX_NUM_LEDS / 2;
     uint64_t ball_counter = 0;
-    int32_t ball_interval = BALL_INTERVAL_START;
+    int32_t ball_interval = PONG_BALL_INTERVAL_START;
+    uint8_t i;
     ButtonState btn1, btn2;
 
 
@@ -198,52 +251,156 @@ uint8_t gameLoop(void) {
             else if(pos >= NPX_NUM_LEDS)
                 return 0;
             clearStrip();
+            for(i=0; i<PONG_RETURN_ZONE_WIDTH; i++)
+                setLEDColor(i, 0, 0, RETURN_ZONE_BRIGHTNESS);
+            for(i=NPX_NUM_LEDS-1; i>=NPX_NUM_LEDS-PONG_RETURN_ZONE_WIDTH; i--)
+                setLEDColor(i, 0, 0, RETURN_ZONE_BRIGHTNESS);
             setLEDColor(pos, 0, 0, 255);
             showStrip();
         }
 
-        if(pos == 0) {
+        if(pos < PONG_RETURN_ZONE_WIDTH && dir < 0) {
             LED_PxOUT |= LED1_PIN;
-            switch(btn1) {
-            case BTN_WAIT:
-                if(BTN_PxIN & BTN1_PIN)
-                    btn1 = BTN_HIGH;
-                break;
-            case BTN_HIGH:
-                if(!(BTN_PxIN & BTN1_PIN)) {
-                    btn1 = BTN_LOW;
-                    dir *= -1;
-                    ball_interval -= BALL_INTERVAL_SPEEDUP;
-                }
-                break;
+            if(btnPressed(&btn1, BTN1_PIN)) {
+                dir *= -1;
+                ball_interval -= PONG_BALL_INTERVAL_SPEEDUP;
             }
         } else {
             LED_PxOUT &= ~(LED1_PIN);
             btn1 = BTN_WAIT;
         }
 
-        if(pos == NPX_NUM_LEDS - 1) {
+        if(pos >= NPX_NUM_LEDS - PONG_RETURN_ZONE_WIDTH && dir > 0) {
             LED_PxOUT |= LED2_PIN;
-            switch(btn2) {
-            case BTN_WAIT:
-                if(BTN_PxIN & BTN2_PIN)
-                    btn2 = BTN_HIGH;
-                break;
-            case BTN_HIGH:
-                if(!(BTN_PxIN & BTN2_PIN)) {
-                    btn2 = BTN_LOW;
-                    dir *= -1;
-                    ball_interval -= BALL_INTERVAL_SPEEDUP;
-                }
-                break;
+            if(btnPressed(&btn2, BTN2_PIN)) {
+                dir *= -1;
+                ball_interval -= PONG_BALL_INTERVAL_SPEEDUP;
             }
         } else {
             LED_PxOUT &= ~(LED2_PIN);
             btn2 = BTN_WAIT;
         }
 
-        if(ball_interval < BALL_INTERVAL_MIN)
-            ball_interval = BALL_INTERVAL_MIN;
+        if(ball_interval < PONG_BALL_INTERVAL_MIN)
+            ball_interval = PONG_BALL_INTERVAL_MIN;
+    }
+}
+
+// Returns 0 if Player 1  wins, 1 if Player 2 wins
+uint8_t gameLoopPingPong(void) {
+    int8_t dir;
+    int32_t pos = NPX_NUM_LEDS / 2;
+    uint64_t ball_counter = 0;
+    uint64_t cooldown = 0;
+    int32_t ball_interval = PINGPONG_BALL_INTERVAL_START;
+    uint8_t i;
+    ButtonState btn1 = BTN_WAIT;
+    ButtonState btn2 = BTN_WAIT;
+
+
+    // Ball should move away from player that releases button first
+    while(1) {
+        if(BTN_PxIN & BTN1_PIN) {
+            dir = 1;
+            break;
+        }
+
+        if(BTN_PxIN & BTN2_PIN) {
+            dir = -1;
+            break;
+        }
+    }
+
+    clearStrip();
+    showStrip();
+
+    while(1) {
+        if(ball_counter + ball_interval <= counter) {
+            ball_counter = counter;
+            pos += dir;
+            if(pos < 0)
+                return 1;
+            else if(pos >= NPX_NUM_LEDS)
+                return 0;
+            clearStrip();
+            for(i=0; i<PINGPONG_RETURN_ZONE_WIDTH; i++)
+                setLEDColor(i, 0, 0, RETURN_ZONE_BRIGHTNESS);
+            for(i=NPX_NUM_LEDS-1; i>=NPX_NUM_LEDS-PINGPONG_RETURN_ZONE_WIDTH; i--)
+                setLEDColor(i, 0, 0, RETURN_ZONE_BRIGHTNESS);
+            setLEDColor(pos, 0, 0, 255);
+            showStrip();
+        }
+
+        if(counter > cooldown) {
+            cooldown = counter + PINGPONG_DEBOUNCE_TIME;
+            if(btnPressed(&btn1, BTN1_PIN)) {
+                btn1 = BTN_WAIT;
+                if(pos < PINGPONG_RETURN_ZONE_WIDTH && dir < 0) {
+                    dir *= -1;
+                    ball_interval -= PINGPONG_BALL_INTERVAL_SPEEDUP;
+                } else {
+                    return 1;
+                }
+            }
+            if(btnPressed(&btn2, BTN2_PIN)) {
+                btn2 = BTN_WAIT;
+                if(pos >= NPX_NUM_LEDS - PINGPONG_RETURN_ZONE_WIDTH && dir > 0) {
+                    dir *= -1;
+                    ball_interval -= PINGPONG_BALL_INTERVAL_SPEEDUP;
+                } else {
+                    return 0;
+                }
+            }
+        }
+
+        if(pos < PINGPONG_RETURN_ZONE_WIDTH && dir < 0) {
+            LED_PxOUT |= LED1_PIN;
+        } else {
+            LED_PxOUT &= ~(LED1_PIN);
+        }
+
+        if(pos >= NPX_NUM_LEDS - PINGPONG_RETURN_ZONE_WIDTH && dir > 0) {
+            LED_PxOUT |= LED2_PIN;
+        } else {
+            LED_PxOUT &= ~(LED2_PIN);
+        }
+
+        if(ball_interval < PINGPONG_BALL_INTERVAL_MIN)
+            ball_interval = PINGPONG_BALL_INTERVAL_MIN;
+    }
+}
+
+// Returns 0 if Player 1  wins, 1 if Player 2 wins
+uint8_t gameLoopTugOWar(void) {
+    int32_t pos = NPX_NUM_LEDS / 2;
+    uint64_t ball_counter = 0;
+    uint64_t cooldown1 = 0;
+    uint64_t cooldown2 = 0;
+    ButtonState btn1 = BTN_WAIT;
+    ButtonState btn2 = BTN_WAIT;
+
+    clearStrip();
+    showStrip();
+
+    while(1) {
+        if(pos < 0)
+            return 1;
+        else if(pos >= NPX_NUM_LEDS)
+            return 0;
+        clearStrip();
+        setLEDColor(pos, 0, 0, 255);
+        showStrip();
+        if(counter > cooldown1) {
+            cooldown1 = counter + TUGOWAR_DEBOUNCE_TIME;
+            if(btnPressed(&btn1, BTN1_PIN)) {
+                btn1 = BTN_WAIT;
+                pos++;
+            }
+            if(btnPressed(&btn2, BTN2_PIN)) {
+                btn2 = BTN_WAIT;
+                pos--;
+            }
+        }
     }
 }
 
@@ -281,11 +438,62 @@ void winnerLoop(uint8_t winner) {
     }
 }
 
+void nextGame(void) {
+    if(game_type == _GAME_LAST)
+        game_type =_GAME_FIRST;
+    else
+        game_type++;
+}
+
+void prevGame(void) {
+    if(game_type == _GAME_FIRST)
+        game_type =_GAME_LAST;
+    else
+        game_type--;
+}
+
+
+void gameSelectLoop(void) {
+    ButtonState btn1 = BTN_WAIT;
+    ButtonState btn2 = BTN_WAIT;
+    uint64_t cooldown = 0;
+    while(1) {
+        if(counter > cooldown) {
+            cooldown = counter + GAME_SELECT_DEBOUNCE_TIME;
+            if(btnPressed(&btn1, BTN1_PIN)) {
+                btn1 = BTN_WAIT;
+                nextGame();
+                continue;
+            }
+            if(btnPressed(&btn2, BTN2_PIN)) {
+                btn2 = BTN_WAIT;
+                prevGame();
+                continue;
+            }
+        }
+        switch(game_type) {
+        case GAME_PONG:
+            drawDemoPong(false);
+            break;
+        case GAME_PINGPONG:
+            drawDemoPingPong(false);
+            break;
+        case GAME_TUGOWAR:
+            drawDemoTugOWar(false);
+            break;
+        }
+        drawGameSelectIndicator();
+    }
+}
+
+
 int main(void)
 {
     uint8_t winner;
 	WDTCTL = WDTPW | WDTHOLD;	// stop watchdog timer
 	
+	fast_srand(PRNG_SEED);
+
 	initGpio();
 
 	initClock();
@@ -296,10 +504,26 @@ int main(void)
 
 	__enable_interrupt();
 
-	while(1) {
-        demoLoop();
-        winner = gameLoop();
-        winnerLoop(winner);
+	if(!(BTN_PxIN & BTN2_PIN)) {
+	    // Activate game selection if button 2 (power handle side)
+	    // is held down when turning on
+	    gameSelectLoop();
+	} else {
+        while(1) {
+            demoLoop();
+            switch(game_type) {
+            case GAME_PONG:
+                winner = gameLoopPong();
+                break;
+            case GAME_PINGPONG:
+                winner = gameLoopPingPong();
+                break;
+            case GAME_TUGOWAR:
+                winner = gameLoopTugOWar();
+                break;
+            }
+            winnerLoop(winner);
+        }
 	}
 
 	return 0;

--- a/firmware/litepog/util.h
+++ b/firmware/litepog/util.h
@@ -1,0 +1,53 @@
+/*
+ * util.h
+ *
+ *  Created on: Dec 13, 2021
+ *      Author: Jasper
+ */
+
+#ifndef UTIL_H_
+#define UTIL_H_
+
+#include <msp430.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "config.h"
+
+typedef enum {
+    BTN_WAIT,
+    BTN_HIGH,
+    BTN_LOW
+} ButtonState;
+
+static uint32_t g_seed;
+
+// Call in a loop to detect falling edge
+bool btnPressed(ButtonState *state, uint8_t pin) {
+    switch(*state) {
+    case BTN_WAIT:
+        if(BTN_PxIN & pin)
+            *state = BTN_HIGH;
+        break;
+    case BTN_HIGH:
+        if(!(BTN_PxIN & pin)) {
+            *state = BTN_LOW;
+            return true;
+        }
+        break;
+    }
+    return false;
+}
+
+
+// Fast random number generator from https://stackoverflow.com/a/26237777
+inline void fast_srand(int seed) {
+    g_seed = seed;
+}
+
+inline uint32_t fast_rand(void) {
+    g_seed = (214013*g_seed+2531011);
+    return (g_seed>>16)&0x7FFF;
+}
+
+
+#endif /* UTIL_H_ */


### PR DESCRIPTION
- Add game type selction (hold down BTN2 on POR)
    - hold down BTN2 on POR to trigger
    - BTN1 and BTN2 to scroll through game types
    - Game type saved to FRAM (remembered on next POR)
- Unique demo animations per game type
- Pong (original game)
    - Return zone width is now configurable
    - Return zone is dimly lit
- PingPong (new game)
    - Based on Light Pong Ping Pong game mode
- Tug O' War (new game)
    - Based on Light Pong Tug O' War game mode
- Fix countdown not being centered properly